### PR TITLE
Keep node_modules/ as they are required at runtime

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,7 +9,6 @@
 **/tsconfig.json
 jest.config.js
 jest.e2e.config.js
-node_modules/**
 out/it/**
 out/tests/**
 src/**


### PR DESCRIPTION
This solution is temporary until we have a better approach. The
initial goal of the trimming of the .vsix was to reduce size of the
package. The archive contains a lot of useless stuff (especially
dev dependencies).

Ideally, we would have one of the following:
- improved pipeline that compiles, but then package with only
`yarn install --production`
- webpack that puts everything in a standalone file