### PR TITLE
Update Smithy grammar

### DIFF
--- a/smithy.tmGrammar.json
+++ b/smithy.tmGrammar.json
@@ -72,7 +72,7 @@
       ]
     },
     "reserved": {
-      "match": "\\b(service|operation|resource|structure|list|metadata|namespace|use|map|union|string|integer|set|blob|boolean|string|byte|short|integer|long|float|double|bigInteger|bigDecimal|timestamp|document|enum|intEnum)\\b",
+      "match": "\\b(service|operation|resource|structure|list|metadata|namespace|use|map|union|string|integer|set|blob|boolean|string|byte|short|integer|long|float|double|bigInteger|bigDecimal|timestamp|document|enum|intEnum|with|for)\\b",
       "name": "keyword.control.reserved"
     },
     "builtin": {

--- a/smithy.tmGrammar.json
+++ b/smithy.tmGrammar.json
@@ -72,7 +72,7 @@
       ]
     },
     "reserved": {
-      "match": "\\b(service|operation|resource|structure|list|metadata|namespace|use|map|union|string|integer|set|blob|boolean|string|byte|short|integer|long|float|double|bigInteger|bigDecimal|timestamp|document)\\b",
+      "match": "\\b(service|operation|resource|structure|list|metadata|namespace|use|map|union|string|integer|set|blob|boolean|string|byte|short|integer|long|float|double|bigInteger|bigDecimal|timestamp|document|enum|intEnum)\\b",
       "name": "keyword.control.reserved"
     },
     "builtin": {


### PR DESCRIPTION
First time I took a jab at this, I completely overlooked some new constructs and thought no changes were required. An obvious mistake in hindsight. I grabbed the getting started example but those new constructs were not in use.

This time, I wrote a Smithy document thats uses them and I could see some keywords missing. In this PR I introduce `for`, `with` that came with mixins and `enum` and `intEnum` as new constructs.

![Screen Shot 2022-08-24 at 09 43 35](https://user-images.githubusercontent.com/5230460/186436814-141fc898-dbe2-4473-8e61-b4d85b6e57ff.png)

![Screen Shot 2022-08-24 at 09 48 11](https://user-images.githubusercontent.com/5230460/186436815-29b7b347-3162-4191-bacc-85f4f0b6533a.png)

![Screen Shot 2022-08-24 at 09 48 14](https://user-images.githubusercontent.com/5230460/186436816-f475b495-eab7-42f0-9ace-fe035a0e45bc.png)

