### PR TITLE
Run CI on main, run tests on non-PRs too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build & test
         run: yarn ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    needs: build
     name: Publish
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags: ["v*"]
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
 
 name: Build and deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 on:
   push:
     tags: ["v*"]
+    branches: ["**"]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 name: Build and deploy
 jobs:
   build:
-    if: github.event_name == 'pull_request'
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
     tags: ["v*"]
     branches: ["**"]
   pull_request:
-    branches: ["**"]
 
 name: Build and deploy
 jobs:


### PR DESCRIPTION
Currently, CI runs only on PRs and tags. In addition, on tags it doesn't run tests again, and it probably doesn't hurt to run them, so I enabled that again, as well as running tests on ~all branches.~ main.