### PR TITLE
Fix extension vsix

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,9 @@
     "vscode": "^1.43.0"
   },
   "dependencies": {
+    "concat-map": "^0.0.2",
     "follow-redirects": "^1.14.9",
+    "semver": "^7.5.0",
     "vscode-languageclient": "^8.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+concat-map@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.2.tgz#f497c5b65881435aa6860a55eb541f1601f63394"
+  integrity sha512-xGo3rY/AH8WxqkYSvsNV9yB79sN2oNVOXnmSMYLx28CVFBsXiEFCkcf6WIiWjk5VWKr4/1fV+KG5I4442xE2hg==
+
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
@@ -3111,7 +3116,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.7:
+semver@^7.3.7, semver@^7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
   integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==


### PR DESCRIPTION
I think this is due to https://github.com/microsoft/vscode-vsce/issues/432 : the modules in question don't appear to be packaged in the VSIX if not listed explicitly.

This is sort of a workaround to fix 0.0.9, which currently fails to launch with the following output in the extension host logs:

```
2023-05-10 17:57:02.530 [error] Activating extension disneystreaming.smithy failed due to an error:
2023-05-10 17:57:02.530 [error] Error: Cannot find module 'concat-map'
Require stack:
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/node_modules/brace-expansion/index.js
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/node_modules/minimatch/minimatch.js
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/node_modules/vscode-languageclient/lib/common/diagnostic.js
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/node_modules/vscode-languageclient/lib/common/client.js
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/node_modules/vscode-languageclient/lib/node/main.js
- /Users/kubukoz/.vscode/extensions/disneystreaming.smithy-0.0.9/out/src/extension.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-amd.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-fork.js
```